### PR TITLE
NMS-15778: k8s: Grafana URL is not accessible from the Grafana Dashboards on index page

### DIFF
--- a/opennms/scripts/onms-grafana-init.sh
+++ b/opennms/scripts/onms-grafana-init.sh
@@ -62,9 +62,16 @@ else
   echo "Configuring Grafana Box for $(hostname)"
   cat <<EOF > ${CONFIG_DIR_OVERLAY}/opennms.properties.d/grafana.properties
 org.opennms.grafanaBox.show=true
-org.opennms.grafanaBox.hostname=${GF_SERVER_DOMAIN}
-org.opennms.grafanaBox.port=443
+org.opennms.grafanaBox.hostname=${GRAFANA_SERVER}
+org.opennms.grafanaBox.port=3000
 org.opennms.grafanaBox.basePath=/
 org.opennms.grafanaBox.apiKey=${GRAFANA_KEY}
+
+# Settings used to build links url in the grafana box in opennms
+org.opennms.grafanaBox.link.protocol=https
+org.opennms.grafanaBox.link.hostname=${GF_SERVER_DOMAIN}
+org.opennms.grafanaBox.link.port=443
+org.opennms.grafanaBox.link.basePath=/
+
 EOF
 fi


### PR DESCRIPTION
We are setting the `org.opennms.grafanaBox.link.*` to the URL that is accessible externally.

In addition, we are setting `org.opennms.grafanaBox.hostname` to the internal URL as this allows OpenNMS to see the Grafana server. 

This was only tested in development environment!