### PR TITLE
Use chart appVersion for default version tags

### DIFF
--- a/examples/minimal-resources.yaml
+++ b/examples/minimal-resources.yaml
@@ -1,14 +1,7 @@
-# Default values for minimal resource consumption, e.g.: minikube (for testing purposes only)
+# Default values for basic core with minimal resource consumption, e.g.: minikube (for testing purposes only)
 
 core:
   resources: null
   configuration:
     storage:
       rrd: 100Gi
-
-grafana:
-  replicaCount: 1
-  resources: null
-  imageRenderer:
-    replicaCount: 1
-    resources: null

--- a/horizon/Chart.yaml
+++ b/horizon/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/horizon/templates/NOTES.txt
+++ b/horizon/templates/NOTES.txt
@@ -1,4 +1,4 @@
-Thank you for installing OpenNMS {{ .Values.core.image.tag | default .Values.opennmsVersion }}.
+Thank you for installing OpenNMS {{ .Values.core.image.tag | default .Chart.AppVersion }}.
 
 Your release is named "{{ .Release.Name }}", used for:
 - Customer/Deployment identifier.

--- a/horizon/templates/grafana-helm.deployment.yaml
+++ b/horizon/templates/grafana-helm.deployment.yaml
@@ -54,7 +54,7 @@ spec:
       containers:
       - name: grafana-helm
         image: {{ printf "%s:%s" .Values.grafana.image.repository .Values.grafana.image.tag }}
-        imagePullPolicy: {{ .Values.grafana.image.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.grafana.image.pullPolicy }}
         ports:
         - containerPort: 3000
           name: http

--- a/horizon/templates/grafana-renderer.deployment.yaml
+++ b/horizon/templates/grafana-renderer.deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: grafana-renderer
         image: {{ printf "%s:%s" .Values.grafana.imageRenderer.image.repository .Values.grafana.imageRenderer.image.tag }}
-        imagePullPolicy: {{ .Values.grafana.imageRenderer.image.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.grafana.imageRenderer.image.pullPolicy }}
         ports:
         - containerPort: 8081
           name: http

--- a/horizon/templates/inspector.yaml
+++ b/horizon/templates/inspector.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.core.inspector.enabled }}
-{{- $image := printf "%s:%s" .Values.core.image.repository (.Values.core.image.tag | default .Values.opennmsVersion) -}}
+{{- $image := printf "%s:%s" .Values.core.image.repository (.Values.core.image.tag | default .Chart.AppVersion) -}}
 ---
 apiVersion: v1
 kind: Pod

--- a/horizon/templates/namespace.yaml
+++ b/horizon/templates/namespace.yaml
@@ -1,4 +1,4 @@
-{{- if not (eq .Release.Name "default") }}
+{{- if and .Values.createNamespace (not (eq .Release.Name "default")) }}
 ---
 apiVersion: v1
 kind: Namespace

--- a/horizon/templates/opennms-core.statefulset.yaml
+++ b/horizon/templates/opennms-core.statefulset.yaml
@@ -1,4 +1,4 @@
-{{- $image := printf "%s:%s" .Values.core.image.repository (.Values.core.image.tag | default .Values.opennmsVersion) -}}
+{{- $image := printf "%s:%s" .Values.core.image.repository (.Values.core.image.tag | default .Chart.AppVersion) -}}
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/horizon/templates/opennms-core.statefulset.yaml
+++ b/horizon/templates/opennms-core.statefulset.yaml
@@ -43,7 +43,7 @@ spec:
       {{- if and (.Values.core.configuration.enableAlec) (.Values.core.configuration.alecImage) }}
       - name: alec-kar
         image: {{ .Values.core.configuration.alecImage.repository }}:{{ .Values.core.configuration.alecImage.tag }}
-        imagePullPolicy: {{ .Values.core.configuration.alecImage.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.core.configuration.alecImage.pullPolicy }}
         command: [ cp, /plugins/opennms-alec-plugin.kar, /opennms-deploy ]
         securityContext: # To guarantee ownership of the KAR file so that OpenNMS won't complain.
           runAsUser: 10001
@@ -55,7 +55,7 @@ spec:
       {{- if and (.Values.core.configuration.enableCortex) (.Values.core.configuration.cortexTssImage) }}
       - name: cortex-tss-kar
         image: {{ .Values.core.configuration.cortexTssImage.repository }}:{{ .Values.core.configuration.cortexTssImage.tag }}
-        imagePullPolicy: {{ .Values.core.configuration.cortexTssImage.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.core.configuration.cortexTssImage.pullPolicy }}
         command: [ cp, /plugins/opennms-cortex-tss-plugin.kar, /opennms-deploy ]
         securityContext: # To guarantee ownership of the KAR file so that OpenNMS won't complain.
           runAsUser: 10001
@@ -68,7 +68,7 @@ spec:
       # Requires the same image/version used at runtime
       - name: init
         image: {{ $image }}
-        imagePullPolicy: {{ .Values.core.image.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.core.image.pullPolicy }}
         command: [ bash, /scripts/onms-core-init.sh ]
         envFrom:
         - configMapRef:
@@ -90,7 +90,7 @@ spec:
       containers:
       - name: onms
         image: {{ $image }}
-        imagePullPolicy: {{ .Values.core.image.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.core.image.pullPolicy }}
         nodeSelector:
           {{- toYaml .Values.core.configuration.nodeSelector | nindent 10 }}
         affinity:

--- a/horizon/templates/opennms-post-config.job.yaml
+++ b/horizon/templates/opennms-post-config.job.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: init
-        image: {{ printf "%s:%s" .Values.core.image.repository (.Values.core.image.tag | default .Values.opennmsVersion) }}
+        image: {{ printf "%s:%s" .Values.core.image.repository (.Values.core.image.tag | default .Chart.AppVersion) }}
         imagePullPolicy: IfNotPresent
         command: [ bash, /scripts/onms-post-init.sh ]
         envFrom:

--- a/horizon/templates/opennms-sentinel.statefulset.yaml
+++ b/horizon/templates/opennms-sentinel.statefulset.yaml
@@ -4,7 +4,7 @@ Use a StatefulSet for Sentinels to have a unique and immutable SENTINEL_ID.
 */}}
 
 {{- if gt ((.Values.sentinel).replicaCount|int) 0 }}
-{{- $image := printf "%s:%s" .Values.sentinel.image.repository (.Values.core.image.tag | default .Values.opennmsVersion) -}}
+{{- $image := printf "%s:%s" .Values.sentinel.image.repository (.Values.core.image.tag | default .Chart.AppVersion) -}}
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/horizon/templates/opennms-sentinel.statefulset.yaml
+++ b/horizon/templates/opennms-sentinel.statefulset.yaml
@@ -38,7 +38,7 @@ spec:
       initContainers:
       - name: init
         image: {{ $image }}
-        imagePullPolicy: {{ .Values.sentinel.image.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.sentinel.image.pullPolicy }}
         command: [ bash, /init.sh ]
         envFrom:
         - configMapRef:
@@ -57,7 +57,7 @@ spec:
       containers:
       - name: sentinel
         image: {{ $image }}
-        imagePullPolicy: {{ .Values.sentinel.image.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.sentinel.image.pullPolicy }}
         args:
         - -c
         ports:

--- a/horizon/templates/opennms-sentinel.statefulset.yaml
+++ b/horizon/templates/opennms-sentinel.statefulset.yaml
@@ -4,7 +4,7 @@ Use a StatefulSet for Sentinels to have a unique and immutable SENTINEL_ID.
 */}}
 
 {{- if gt ((.Values.sentinel).replicaCount|int) 0 }}
-{{- $image := printf "%s:%s" .Values.sentinel.image.repository (.Values.core.image.tag | default .Chart.AppVersion) -}}
+{{- $image := printf "%s:%s" .Values.sentinel.image.repository (.Values.sentinel.image.tag | default .Chart.AppVersion) -}}
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/horizon/values.yaml
+++ b/horizon/values.yaml
@@ -4,7 +4,6 @@
 
 timezone: America/New_York
 domain: example.com # The common domain for the Ingress resource.
-opennmsVersion: '32.0.0-SNAPSHOT'
 
 # Optionally specify an array of imagePullSecrets.
 # Secrets must be manually created in the namespace.
@@ -95,7 +94,7 @@ core:
   image:
     repository: opennms/horizon
     pullPolicy: IfNotPresent
-    tag: '' # Defaults to opennmsVersion
+    tag: '' # Defaults to the chart appVersion
   resources:
     limits:
       cpu: '2'
@@ -151,7 +150,7 @@ sentinel:
   image:
     repository: opennms/sentinel
     pullPolicy: IfNotPresent
-    tag: '' # Defaults to opennmsVersion
+    tag: '' # Defaults to the chart appVersion
   resources:
     limits:
       cpu: '2'

--- a/horizon/values.yaml
+++ b/horizon/values.yaml
@@ -4,6 +4,7 @@
 
 timezone: America/New_York
 domain: example.com  # The common domain for the Ingress resource.
+createNamespace: true  # Whether to create the namespace for this deployment
 
 # Optionally specify an array of imagePullSecrets.
 # Secrets must be manually created in the namespace.

--- a/horizon/values.yaml
+++ b/horizon/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 timezone: America/New_York
-domain: example.com # The common domain for the Ingress resource.
+domain: example.com  # The common domain for the Ingress resource.
 
 # Optionally specify an array of imagePullSecrets.
 # Secrets must be manually created in the namespace.
@@ -21,34 +21,34 @@ dependencies:
 
   # A common JKS to white-list all CA certificates for all the dependencies OpenNMS or Sentinel uses.
   truststore:
-    content: '' # A base64 encoded content of the JKS Truststore file.
+    content: ''  # A base64 encoded content of the JKS Truststore file.
     password: '0p3nNM5'
 
   # The main OpenNMS database requires PostgreSQL (this is mandatory).
   postgresql:
-    hostname: onms-db.shared.svc # IP or FQDN of the external PostgreSQL server
+    hostname: onms-db.shared.svc  # IP or FQDN of the external PostgreSQL server
     port: 5432
     username: postgres
     password: P0stgr3s
-    sslmode: require # disable, allow, prefer, require, verify-ca, verify-full
-    sslfactory: org.postgresql.ssl.LibPQFactory # LibPQFactory, DefaultJavaSSLFactory, NonValidatingFactory
-    caCert: '' # A base64 encoded content of the CA Certificate
+    sslmode: require  # disable, allow, prefer, require, verify-ca, verify-full
+    sslfactory: org.postgresql.ssl.LibPQFactory  # LibPQFactory, DefaultJavaSSLFactory, NonValidatingFactory
+    caCert: ''  # A base64 encoded content of the CA Certificate
 
   # The chosen broker technology for the Minion-to-OpenNMS communication (this is mandatory).
   # For TLS with private CA, use the common Truststore.
   kafka:
-    hostname: '' # IP or FQDN of the external Kafka server (Example: onms-kafka-bootstrap.shared.svc)
+    hostname: ''  # IP or FQDN of the external Kafka server (Example: onms-kafka-bootstrap.shared.svc)
     port: 9093
-    username: opennms # Pass empty username when using saslMechanism=PLAIN
-    password: 0p3nNM5 # Pass empty password when using saslMechanism=PLAIN
+    username: opennms  # Pass empty username when using saslMechanism=PLAIN
+    password: 0p3nNM5  # Pass empty password when using saslMechanism=PLAIN
     configuration:
-      saslMechanism: SCRAM-SHA-512 # PLAIN, SCRAM-SHA-512
-      securityProtocol: SASL_SSL # PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL
+      saslMechanism: SCRAM-SHA-512  # PLAIN, SCRAM-SHA-512
+      securityProtocol: SASL_SSL  # PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL
 
   # Persisting flows requires Elasticsearch
   # For TLS with private CA, use the common Truststore.
   elasticsearch:
-    hostname: '' # IP or FQDN of the external Elasticsearch server (Example: onms-es-http.shared.svc)
+    hostname: ''  # IP or FQDN of the external Elasticsearch server (Example: onms-es-http.shared.svc)
     port: 9200
     username: elastic
     password: 31@st1c
@@ -60,10 +60,10 @@ dependencies:
 
   # The chosen solution for log aggregation (OpenNMS and Sentinel will forward logs to it via Promtail)
   loki:
-    hostname: '' # IP or FQDN of the external Loki server (Example: loki.shared.svc); '' to disable
+    hostname: ''  # IP or FQDN of the external Loki server (Example: loki.shared.svc); '' to disable
     username: ''
     password: ''
-    caCert: '' # A base64 encoded content of the CA Certificate (assumes HTTPS for Loki's URL)
+    caCert: ''  # A base64 encoded content of the CA Certificate (assumes HTTPS for Loki's URL)
     port: 3100
 
   # The metrics persistence layer as an alternative to RRDtool.
@@ -77,7 +77,7 @@ dependencies:
     readTimeoutInMs: 1000
     metricCacheSize: 1000
     externalTagsCacheSize: 1000
-    bulkheadMaxWaitDuration: '9223372036854775807' # this is set as a string so it doesn't end up in scientific notation along the way which causes problems later
+    bulkheadMaxWaitDuration: '9223372036854775807'  # this is set as a string so it doesn't end up in scientific notation along the way which causes problems later
 
 # The Ingress to expose the OpenNMS and Grafana.
 ingress:
@@ -88,13 +88,13 @@ ingress:
 
 # OpenNMS Core Instance.
 core:
-  inspector: 
+  inspector:
     enabled: false
   terminationGracePeriodSeconds: 120
   image:
     repository: opennms/horizon
     pullPolicy: IfNotPresent
-    tag: '' # Defaults to the chart appVersion
+    tag: ''  # Defaults to the chart appVersion
   resources:
     limits:
       cpu: '2'
@@ -104,11 +104,11 @@ core:
       memory: 4Gi
   configuration:
     alwaysRollDeployment: true
-    enableAlec: false    # See alecImage below for how the KAR is retrieved
-    enableCortex: false # See cortexTssImage below for how the KAR is retrieved
+    enableAlec: false  # See alecImage below for how the KAR is retrieved
+    enableCortex: false  # See cortexTssImage below for how the KAR is retrieved
     enableTssDualWrite: false
     enableAcls: false
-    rras: # To optionally replace the RRDtool aggregations (pass [] to keep defaults). Affects Pollerd and Collectd
+    rras:  # To optionally replace the RRDtool aggregations (pass [] to keep defaults). Affects Pollerd and Collectd
     - RRA:AVERAGE:0.5:1:2016
     - RRA:AVERAGE:0.5:12:1488
     - RRA:AVERAGE:0.5:288:366
@@ -124,19 +124,19 @@ core:
 #      repository: opennms/opennms-cortex-tss-plugin
 #      pullPolicy: IfNotPresent
 #      tag: v2.0.1
-    database: # Access to the OpenNMS database
+    database:  # Access to the OpenNMS database
       username: opennms
       password: 0p3nNM5
       poolSize: 50
-    storage: # Sizes for RRDs and configuration
-      etc: 1Gi # Warning Google Filestore enforces 1TB at a minimum
-      rrd: 1000Gi # Depends on how many files you are planning to have (each installation is different)
-      mibs: null # Expects a size, e.g.: 1Gi
-    http: # Credentials to access the WebUI
-      restUsername: opennms # ReST user for Grafana/Helm, Sentinel and Minions (when Twin API is not available)
+    storage:  # Sizes for RRDs and configuration
+      etc: 1Gi  # Warning Google Filestore enforces 1TB at a minimum
+      rrd: 1000Gi  # Depends on how many files you are planning to have (each installation is different)
+      mibs: null  # Expects a size, e.g.: 1Gi
+    http:  # Credentials to access the WebUI
+      restUsername: opennms  # ReST user for Grafana/Helm, Sentinel and Minions (when Twin API is not available)
       restPassword: 0p3nNM5
-      adminPassword: 0p3nNM5 # Password for the default admin account
-    etcUpdatePolicy: newer # Experimental: options: never (don't update any files), newer (only newer timestamps), new (only brand new files)
+      adminPassword: 0p3nNM5  # Password for the default admin account
+    etcUpdatePolicy: newer  # Experimental: options: never (don't update any files), newer (only newer timestamps), new (only brand new files)
     nodeSelector: null
     affinity: null
     tolerations: null
@@ -145,12 +145,12 @@ core:
 
 # OpenNMS Sentinel for flow processing (Optional)
 sentinel:
-  replicaCount: 0 # Use 0 to disable
+  replicaCount: 0  # Use 0 to disable
   terminationGracePeriodSeconds: 60
   image:
     repository: opennms/sentinel
     pullPolicy: IfNotPresent
-    tag: '' # Defaults to the chart appVersion
+    tag: ''  # Defaults to the chart appVersion
   resources:
     limits:
       cpu: '2'
@@ -179,16 +179,16 @@ grafana:
       memory: 128Mi
   configuration:
     ui:
-      adminPassword: 0p3nNM5 # Default password for the admin account
-    database: # Assumes PostgreSQL
+      adminPassword: 0p3nNM5  # Default password for the admin account
+    database:  # Assumes PostgreSQL
       username: grafana
       password: Gr@f@n@
-      sslmode: require # disable, require, verify-full
-      image: # For the initialization container to create the database
+      sslmode: require  # disable, require, verify-full
+      image:  # For the initialization container to create the database
         repository: postgres
         pullPolicy: IfNotPresent
         tag: '13'
-  imageRenderer: # Required to generate PDF reports from OpenNMS
+  imageRenderer:  # Required to generate PDF reports from OpenNMS
     replicaCount: 2
     image:
       repository: grafana/grafana-image-renderer

--- a/minion/Chart.yaml
+++ b/minion/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/minion/templates/minion-deployment.yaml
+++ b/minion/templates/minion-deployment.yaml
@@ -1,3 +1,4 @@
+{{- $image := printf "%s:%s" .Values.minion.image.repository (.Values.minion.image.tag | default .Chart.AppVersion) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -31,7 +32,8 @@ spec:
             {{- end }}
             - name: TZ
               value: America/New_York
-          image: opennms/minion:{{ .Chart.AppVersion }}
+          image: {{ $image }}
+          imagePullPolicy: {{ .Values.minion.image.pullPolicy }}
           livenessProbe:
             exec:
               command:

--- a/minion/templates/minion-deployment.yaml
+++ b/minion/templates/minion-deployment.yaml
@@ -31,7 +31,7 @@ spec:
             {{- end }}
             - name: TZ
               value: America/New_York
-          image: opennms/minion:{{ .Values.opennmsVersion }}
+          image: opennms/minion:{{ .Chart.AppVersion }}
           livenessProbe:
             exec:
               command:

--- a/minion/values.yaml
+++ b/minion/values.yaml
@@ -8,6 +8,11 @@ minion:
  configuration:
   storage:
    dataFolder: 5Gi
+ image:
+  repository: opennms/minion
+  pullPolicy: IfNotPresent
+  tag: '' # Defaults to the chart appVersion
+
 
 core:
  instanceID: monms # Must match OpenNMS Core instance (namespace) 

--- a/minion/values.yaml
+++ b/minion/values.yaml
@@ -1,5 +1,3 @@
-opennmsVersion: '32.0.0-SNAPSHOT' # Must match OpenNMS Core version
-
 minion:
  location: pod
  name: myminion

--- a/minion/values.yaml
+++ b/minion/values.yaml
@@ -11,13 +11,13 @@ minion:
  image:
   repository: opennms/minion
   pullPolicy: IfNotPresent
-  tag: '' # Defaults to the chart appVersion
+  tag: ''  # Defaults to the chart appVersion
 
 
 core:
- instanceID: monms # Must match OpenNMS Core instance (namespace) 
-   
+ instanceID: monms  # Must match OpenNMS Core instance (namespace)
+
 # A common JKS to white-list all CA certificates .
 truststore:
- content: '' # A base64 encoded content of the JKS Truststore file.
+ content: ''  # A base64 encoded content of the JKS Truststore file.
  password: ''

--- a/scripts/k8s_on_docker_desktop.sh
+++ b/scripts/k8s_on_docker_desktop.sh
@@ -61,7 +61,6 @@ echo "Domain: $our_domain" | tee -a $log_file
 echo "Kafka Domain: $our_kafka_domain" | tee -a $log_file
 echo "Namespace: $our_namespace" | tee -a $log_file
 echo $(grep "appVersion: \?" ${root_path}horizon/Chart.yaml)
-echo $(grep "opennmsVersion: \?" ${root_path}horizon/values.yaml)
 echo ""
 
 # Maybe switch this check to \(onms-core\|*\).$our_namespace.$our_domain

--- a/scripts/update_OpenNMS_core_Version.sh
+++ b/scripts/update_OpenNMS_core_Version.sh
@@ -17,13 +17,6 @@ if [ ! -d "examples" ]; then
 fi
 
 
-printf "\033[36m%s\033[0m:\033[0m\033[33m %s\n\033[0m" "Step 1" "Modifying opennms/values.yaml"
-sed -rie 's/(opennmsVersion: ?).*/\1'$new_version'/g' "${root_path}opennms/values.yaml"
-if [ -f "${root_path}opennms/values.yamle" ]; then
- rm ${root_path}opennms/values.yamle
-fi
-echo ""
-
 printf "\033[36m%s\033[0m:\033[0m\033[33m %s\n\033[0m" "Step 2" "Modifying opennms/Chart.yaml"
 sed -rie 's/(appVersion: ?).*/\1\"'$new_version'\"/g' "${root_path}opennms/Chart.yaml"
 if [ -f "${root_path}opennms/Chart.yamle" ]; then


### PR DESCRIPTION
- Switch from using .Values.opennmsVersion to .Chart.AppVersion
- Fix: make sure sentinal uses its own image.tag, not core's
- Minion: Give it the same image configurability as core/sentinel
- Fix the value references to *.image.pullPolicy
