### PR TITLE
NMS-15822: Add support for etc configmaps that get copied to the overlay

### DIFF
--- a/horizon/Chart.yaml
+++ b/horizon/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/horizon/README.md
+++ b/horizon/README.md
@@ -64,6 +64,7 @@ helm install monms opennms/horizon --set domain=domain1.com  --create-namespace
 | core.image.repository | string | `"opennms/horizon"` |  |
 | core.image.tag | string | `""` |  |
 | core.inspector.enabled | bool | `false` |  |
+| core.overlayConfigMaps | list | `[]` |  |
 | core.postConfigJob.ttlSecondsAfterFinished | int | `300` |  |
 | core.resources.limits.cpu | string | `"2"` |  |
 | core.resources.limits.memory | string | `"8Gi"` |  |

--- a/horizon/README.md
+++ b/horizon/README.md
@@ -25,6 +25,71 @@ helm install monms opennms/horizon --set domain=domain1.com  --create-namespace
 | ----------- | ----------- | ----------- |
 | 1.x | Horizon 32.x | Meridian 2023.x |
 
+## Overlay ConfigMaps
+
+The chart supports specifying a list of ConfigMaps with `core.overlayConfigMaps` that will be copied to the OpenNMS container overlay directory in the init container. This can be used to provide configuration files for OpenNMS. There are two ways to provide content in each ConfigMap:
+
+### Plain files
+
+Provide one or more plain files (text and/or binary) in the ConfigMap and specify the directory where these files we be copied.
+
+Here is a configuration example:
+
+```
+core:
+  overlayConfigMaps:
+    - name: "my-etc-files"
+      path: "etc"
+```
+
+Here is an example of how to create the ConfigMap:
+
+```
+instance=<helm release name> # make sure to set to your Helm release name
+configmap=my-etc-files
+
+mkdir etc
+date > etc/testing-configmap
+
+kubectl create configmap -n $instance $configmap --from-file=etc
+```
+
+### ZIP files
+
+Provide one or more ZIP files in the ConfigMap, and each will be extracted in alphabetical order at the root of the overlay directory.
+
+Here is a configuration example:
+
+```
+core:
+  overlayConfigMaps:
+    - name: "my-zip-files"
+      unzip: true
+```
+
+Here is an example of how to create the ConfigMap:
+
+```
+instance=<helm release name> # make sure to set to your Helm release name
+configmap=my-zip-files
+
+mkdir -p zip/etc
+dd if=/dev/zero bs=1k count=5000 of=zip/etc/lots-of-zeros # make a 5 MB test file
+( cd zip && zip -r -o ../lots-of-zeros.zip . )
+
+kubectl create configmap -n $instance $configmap --from-file=lots-of-zeros.zip
+```
+
+### Overlay ConfigMap Notes
+
+1. This mechanism can only be used to *add* files. When `etc` files are copied into the `onms-etc-pvc` PVC, removing a file from the ConfigMap will not cause the file in the PVC to be *deleted*. In this case, you will need to delete the file manually **after** updating the ConfigMap to remove the file. You can do this with `kubectl exec -n $instance onms-core-0 -- rm etc/testing-configmap`.
+2. ConfigMaps cannot contain recursive directory structures--only files. If you need to put files into multiple directories, each directory will need to be its own ConfigMap. `kubectl create configmap` will silently ignore sub-directories.
+3. ConfigMaps can't be larger than 1 MB (see the note [here](https://kubernetes.io/docs/concepts/configuration/configmap/#motivation). If you have more content, it will need to be split across multiple ConfigMaps or compressed into ZIP files.
+4. Use `kubectl delete configmap -n $instance $configmap` to delete an existing ConfigMap before updating.
+5. After updating a ConfigMap, you will need to restart the pod, for example: `kubectl rollout restart -n $instance statefulset/onms-core`
+6. You can use `kubectl get configmap -n $instance $configmap -o yaml` to view the ConfigMap that is created.
+7. Due to file ownership, some files/directories might not be updatable in the container at runtime. A workaround is to build a modified container that updates permissions with `chmod -R g=u ...` on the affected files/directories. See the OpenNMS [core Dockerfile](https://github.com/OpenNMS/opennms/blob/develop/opennms-container/core/Dockerfile) for which directories have been updated to allow writes out-of-the-box.
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/horizon/README.md.gotmpl
+++ b/horizon/README.md.gotmpl
@@ -25,6 +25,71 @@ helm install monms opennms/horizon --set domain=domain1.com  --create-namespace
 | ----------- | ----------- | ----------- |
 | 1.x | Horizon 32.x | Meridian 2023.x |
 
+## Overlay ConfigMaps
+
+The chart supports specifying a list of ConfigMaps with `core.overlayConfigMaps` that will be copied to the OpenNMS container overlay directory in the init container. This can be used to provide configuration files for OpenNMS. There are two ways to provide content in each ConfigMap:
+
+### Plain files
+
+Provide one or more plain files (text and/or binary) in the ConfigMap and specify the directory where these files we be copied.
+
+Here is a configuration example:
+
+```
+core:
+  overlayConfigMaps:
+    - name: "my-etc-files"
+      path: "etc"
+```
+
+Here is an example of how to create the ConfigMap:
+
+
+```
+instance=<helm release name> # make sure to set to your Helm release name
+configmap=my-etc-files
+
+mkdir etc
+date > etc/testing-configmap
+
+kubectl create configmap -n $instance $configmap --from-file=etc
+```
+
+### ZIP files
+
+Provide one or more ZIP files in the ConfigMap, and each will be extracted in alphabetical order at the root of the overlay directory.
+
+Here is a configuration example:
+
+```
+core:
+  overlayConfigMaps:
+    - name: "my-zip-files"
+      unzip: true
+```
+
+Here is an example of how to create the ConfigMap:
+
+```
+instance=<helm release name> # make sure to set to your Helm release name
+configmap=my-zip-files
+
+mkdir -p zip/etc
+dd if=/dev/zero bs=1k count=5000 of=zip/etc/lots-of-zeros # make a 5 MB test file
+( cd zip && zip -r -o ../lots-of-zeros.zip . )
+
+kubectl create configmap -n $instance $configmap --from-file=lots-of-zeros.zip
+```
+
+### Overlay ConfigMap Notes
+
+1. This mechanism can only be used to *add* files. When `etc` files are copied into the `onms-etc-pvc` PVC, removing a file from the ConfigMap will not cause the file in the PVC to be *deleted*. In this case, you will need to delete the file manually **after** updating the ConfigMap to remove the file. You can do this with `kubectl exec -n $instance onms-core-0 -- rm etc/testing-configmap`.
+2. ConfigMaps cannot contain recursive directory structures--only files. If you need to put files into multiple directories, each directory will need to be its own ConfigMap. `kubectl create configmap` will silently ignore sub-directories.
+3. ConfigMaps can't be larger than 1 MB (see the note [here](https://kubernetes.io/docs/concepts/configuration/configmap/#motivation). If you have more content, it will need to be split across multiple ConfigMaps or compressed into ZIP files.
+4. Use `kubectl delete configmap -n $instance $configmap` to delete an existing ConfigMap before updating.
+5. After updating a ConfigMap, you will need to restart the pod, for example: `kubectl rollout restart -n $instance statefulset/onms-core`
+6. You can use `kubectl get configmap -n $instance $configmap -o yaml` to view the ConfigMap that is created.
+7. Due to file ownership, some files/directories might not be updatable in the container at runtime. A workaround is to build a modified container that updates permissions with `chmod -R g=u ...` on the affected files/directories. See the OpenNMS [core Dockerfile](https://github.com/OpenNMS/opennms/blob/develop/opennms-container/core/Dockerfile) for which directories have been updated to allow writes out-of-the-box.
 
 {{ template "chart.valuesSection" . }}
 

--- a/horizon/templates/opennms-core.statefulset.yaml
+++ b/horizon/templates/opennms-core.statefulset.yaml
@@ -121,6 +121,20 @@ spec:
           mountPath: /opt/opennms-overlay # Required by the script - OVERLAY_DIR
         - name: scripts
           mountPath: /scripts # Required by the script
+        {{- range $k, $r := .Values.core.overlayConfigMaps }}
+        - name: overlay-configmap-{{ $k }}
+          {{- if $r.unzip }}
+            {{- if $r.path }}
+              {{- printf "path not allowed when unzip is true for core.overlayConfigMaps with name '%s'" $r.name | fail }}
+            {{- end }}
+          mountPath: /opennms-overlay-configmaps/{{ $k }}-unzip
+          {{- else }}
+            {{- if empty $r.path }}
+              {{- printf "path required for core.overlayConfigMaps with name '%s'" $r.name | fail }}
+            {{- end }}
+          mountPath: /opennms-overlay-configmaps/{{ $k }}/{{ $r.path }}
+          {{- end }}
+        {{- end }}
       nodeSelector:
         {{- toYaml .Values.core.configuration.nodeSelector | nindent 8 }}
       affinity:
@@ -289,4 +303,9 @@ spec:
         persistentVolumeClaim:
           claimName: onms-mibs-pvc
           readOnly: false
+      {{- end }}
+      {{- range $k, $r := .Values.core.overlayConfigMaps }}
+      - name: overlay-configmap-{{ $k }}
+        configMap:
+          name: {{ $r.name | quote }}
       {{- end }}

--- a/horizon/values.yaml
+++ b/horizon/values.yaml
@@ -108,6 +108,7 @@ ingress:
 core:
  inspector:
   enabled: false
+ overlayConfigMaps: []
  terminationGracePeriodSeconds: 120
  image:
   repository: opennms/horizon


### PR DESCRIPTION
This is a PoC and is likely not yet complete, except for a basic, initial solution:
* [x] We want to think about what to do for content outside of etc -- do we add separate configmaps for each overlay? Use the global overlay?
* [x] Haven't tested binary content yet
* [x] Docs changes
* [x] Should test with > 10 configmaps to make sure the ordering is correct
* [x] Nothing is done with uncompressing content yet (or should that be a different PR? Or go into the entrypoint of the dockerfile)
* [x] Is the ".uncompress" file the right way to trigger the uncompress logic? Should it always be on?
* [x] Make sure we get ownership/permissions right for OpenShift in particular (it's fine for `etc`, but will need work in the container for other directories)
* [x] ~~Any scripting/Helm charts to help make configmaps for multiple directories~~--not needed with ZIP support
* [x] Make sure the characters in the files we use are allowed by the configmap key regex -- nah, just toss 'em in an archive
* [x] Should we support extracting archives? (zip, tar.gz) -- YES
* [x] Should we do as much of this in the Docker container instead of here? -- NO, not now
* [x] Add support for ZIP archives (and remove support for .gz--we'll only support one compression/archive format for simplicity and documentation)

## future possibilities

* Support arbitrary user-specific init containers.
* Make the etc pvc optional (maybe even disabled by default eventually?)
* Git workflow for editing etc files, merging changes between versions, etc..
* We could possibly add support for files that can be updated while Horizon is running.
* Support a zip or tar.gz of files

## To test

```
# set your namespace first
instance=whatever
configmap=foobaz

mkdir etc
date > etc/testing-configmap
kubectl create configmap -n $instance $configmap --from-file=etc
kubectl get configmap -n $instance $configmap -o yaml
helm upgrade --reuse-values $instance . --set "core.overlayConfigMaps[0].name=$configmap" --set 'core.overlayConfigMaps[0].path=etc'
```

Output from the init container:
```
Processing overlay config maps ...
  Copying files from /opennms-overlay-configmaps/0 to /opt/opennms-overlay/ ...
    etc/testing-configmap c0f178d439e947ba9d62abb519fe56af
```

## Notes
If the pod doesn't start, check events -- maybe the configmap name is wrong and can't be mounted:
```
kubectl events -n $instance
```

Remove the configmap before creating a new one:
```
kubectl delete configmap -n $instance $configmap
```

When you update the configmap, **the pod will not automatically restart**. You'll have to do that:
```
kubectl rollout restart -n $instance statefulset/onms-core
```

## Testing
### Binary content
```
$ dd if=/dev/urandom of=etc/random-file bs=1k count=1
1+0 records in
1+0 records out
1024 bytes transferred in 0.000158 secs (6481013 bytes/sec)
$ md5sum etc/random-file
ad428160a7518cd5893bd2a6c3b09938  etc/random-file
```

Updating the configmap and restarting the pod:
```
kubectl delete configmap -n $instance $configmap
kubectl create configmap -n $instance $configmap --from-file=etc
kubectl get configmap -n $instance $configmap -o yaml
kubectl rollout restart -n $instance statefulset/onms-core
```

Inside the container after updating the configmap and restarting the pod:
```
opennms@onms-core-0:~$ md5sum etc/random-file
ad428160a7518cd5893bd2a6c3b09938  etc/random-file
```

### configmap with .zip file

Make a big file of zeros and add to a .zip file
```
mkdir -p zip/etc
dd if=/dev/zero bs=1k count=5000 of=zip/etc/lots-of-zeros
md5sum zip/etc/lots-of-zeros
# output is: 56179b2937a6e956250ab491685a4efb  zip/etc/lots-of-zeros
( cd zip && zip -r -o ../lots-of-zeros.zip . )
```

Update the configmap and update the helm chart to unzip the configmap:
```
kubectl delete configmap -n $instance $configmap
kubectl create configmap -n $instance $configmap --from-file=lots-of-zeros.zip
kubectl get configmap -n $instance $configmap -o yaml
helm upgrade --reuse-values $instance . --set "core.overlayConfigMaps[0].name=$configmap" --set 'core.overlayConfigMaps[0].path=null' --set 'core.overlayConfigMaps[0].unzip=true'
```

Inside the container after updating the configmap and restarting the pod:
```
opennms@onms-core-0:~$ md5sum etc/lots-of-zeros
56179b2937a6e956250ab491685a4efb  etc/lots-of-zeros
```

Output from the init container:
```
Processing overlay config maps ...
  Extracting files from /opennms-overlay-configmaps/0-unzip/lots-of-zeros.zip to /opt/opennms-overlay/ ...
    Archive:  /opennms-overlay-configmaps/0-unzip/lots-of-zeros.zip
      inflating: /opt/opennms-overlay/etc/lots-of-zeros
```

