### PR TITLE
Make cert-manager optional, add ingress-nginx, tweak workflows

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -47,13 +47,7 @@ jobs:
 
       - name: Setup dependencies
         if: steps.list-changed.outputs.changed == 'true'
-        run: |
-          helm upgrade --install ingress-nginx ingress-nginx \
-          --repo https://kubernetes.github.io/ingress-nginx \
-          --namespace ingress-nginx --create-namespace 
-          cd scripts
-          ./start-dependencies.sh
-          cd ..
+        run: scripts/start-dependencies.sh
             
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --chart-dirs . --validate-maintainers=false  --target-branch ${{ github.event.repository.default_branch }} --check-version-increment=false
+        run: ct lint --chart-dirs . --validate-maintainers=false  --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
   branches:
      - main
 
+# Make sure only one copy of this workflow can run at a time.
+concurrency: ${{ github.workflow }}
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/scripts/k8s_on_docker_desktop.sh
+++ b/scripts/k8s_on_docker_desktop.sh
@@ -82,17 +82,6 @@ printf "\033[36m%s\033[0m:\033[0m\033[33m %s\n\033[0m" "Step 1" "Modifying depen
 sed -rie 's/(host: kafka(-0)?).*/\1'$our_kafka_domain'/g' "${root_path}dependencies/kafka.yaml"
 echo ""
 
-# Ingress is not really active/installed, lets install it
-printf "\033[36m%s\033[0m:\033[0m\033[33m %s\n\033[0m" "Step 2" "Check/Install Ingress"
-helm upgrade --install ingress-nginx ingress-nginx \
-  --repo https://kubernetes.github.io/ingress-nginx \
-  --namespace ingress-nginx --create-namespace >> $log_file 2>&1
-checkRC
-
-sleep 10
-
-echo ""
-
 # Start the dependencies
 printf "\033[36m%s\033[0m:\033[0m\033[33m %s\n\033[0m" "Step 3" "Starting Dependencies"
 ${root_path}scripts/start-dependencies.sh  >> $log_file 2>&1


### PR DESCRIPTION
- start-dependencies.sh: make cert-manager optional, add ingress-nginx
- Revert "Don't always require version bump: we don't always release when merging"
- Make sure only one copy of the release workflow can run at a time
