### PR TITLE
Experimental: support configuring additional init containers for Horizon

### DIFF
--- a/horizon/Chart.yaml
+++ b/horizon/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.4
+version: 1.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/horizon/README.md
+++ b/horizon/README.md
@@ -128,6 +128,7 @@ kubectl create configmap -n $instance $configmap --from-file=lots-of-zeros.zip
 | core.image.pullPolicy | string | `"IfNotPresent"` |  |
 | core.image.repository | string | `"opennms/horizon"` |  |
 | core.image.tag | string | `""` |  |
+| core.initContainers | list | `[]` | Experimental: a list of additional init containers |
 | core.inspector.enabled | bool | `false` |  |
 | core.overlayConfigMaps | list | `[]` |  |
 | core.postConfigJob.ttlSecondsAfterFinished | int | `300` |  |

--- a/horizon/templates/opennms-core.statefulset.yaml
+++ b/horizon/templates/opennms-core.statefulset.yaml
@@ -135,6 +135,9 @@ spec:
           mountPath: /opennms-overlay-configmaps/{{ $k }}/{{ $r.path }}
           {{- end }}
         {{- end }}
+      {{- with .Values.core.initContainers }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       nodeSelector:
         {{- toYaml .Values.core.configuration.nodeSelector | nindent 8 }}
       affinity:

--- a/horizon/values.yaml
+++ b/horizon/values.yaml
@@ -171,6 +171,8 @@ core:
     externalPort: 8101
  postConfigJob:
   ttlSecondsAfterFinished: 300
+ # -- Experimental: a list of additional init containers
+ initContainers: []
 
 # OpenNMS Sentinel for flow processing (Optional)
 sentinel:

--- a/scripts/start-dependencies.sh
+++ b/scripts/start-dependencies.sh
@@ -39,12 +39,6 @@ ELASTIC_PASSWORD="31@st1c" # Must match dependencies.elasticsearch.password from
 TRUSTSTORE_PASSWORD="0p3nNM5" # Must match dependencies.kafka.truststore.password from the Helm deployment
 CLUSTER_NAME="onms" # Must match the name of the cluster inside dependencies/kafka.yaml and dependencies/elasticsearch.yaml
 
-# Patch NGinx to allow SSL Passthrough for Strimzi
-if [ "$INSTALL_KAFKA" == "true" ]; then
-  kubectl patch deployment ingress-nginx-controller -n ingress-nginx --type json -p \
-    '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--enable-ssl-passthrough"}]'
-fi
-
 # Update Helm Repositories
 helm repo add jetstack https://charts.jetstack.io
 helm repo add grafana https://grafana.github.io/helm-charts
@@ -52,17 +46,35 @@ helm repo update
 
 # Install Cert-Manager
 if [ "$INSTALL_CERT_MANAGER" == "true" ]; then
+  # The --leader-elect=false significantly decreases startup time
   helm upgrade --install cert-manager jetstack/cert-manager --version v1.10.1 \
-    --namespace cert-manager --create-namespace --set installCRDs=true --wait
+    --namespace cert-manager --create-namespace --set installCRDs=true \
+    --set 'cainjector.extraArgs={--leader-elect=false}'
   kubectl apply -f ca -n cert-manager
 fi
 
 # Install ingress-nginx
 if [ "$INSTALL_INGRESS_NGINX" == "true" ]; then
+  declare -a ingress_nginx_helm_args # Make old bash 3.x 3.x on macOS happy
+  if [ "$INSTALL_KAFKA" == "true" ]; then
+    # Patch NGinx to allow SSL Passthrough for Strimzi
+    ingress_nginx_helm_args=('--set' 'ingress-nginx.params=["--enable-leader-election=false", "--enable-ssl-passthrough"]')
+  else
+    ingress_nginx_helm_args=('--set' 'ingress-nginx.params=["--enable-leader-election=false"]')
+  fi
+
+  # The controller.service.type=NodePort is because kind doesn't provide a LoadBalancer by default.
+  # https://github.com/fluxcd/flux2/issues/2476#issuecomment-1051275654
   helm upgrade --install ingress-nginx ingress-nginx \
     --repo https://kubernetes.github.io/ingress-nginx \
     --version 4.8.3 \
-    --namespace ingress-nginx --create-namespace
+    --namespace ingress-nginx --create-namespace \
+    --set controller.service.type=NodePort \
+    "${ingress_nginx_helm_args[@]}"
+elif [ "$INSTALL_KAFKA" == "true" ]; then
+  # Patch NGinx to allow SSL Passthrough for Strimzi
+  kubectl patch deployment ingress-nginx-controller -n ingress-nginx --type json -p \
+    '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--enable-ssl-passthrough"}]'
 fi
 
 # Create a namespace for most of the dependencies except for cert-manager and ingress-nginx (above), and the postgres and elastic operators (added below).
@@ -132,7 +144,14 @@ if [ "$INSTALL_MIMIR" == "true" ]; then
     -f dependencies/values-mimir.yaml
 fi
 
-# Wait for the clusters
+# Wait for everything
+if [ "$INSTALL_INGRESS_NGINX" == "true" ]; then
+  # https://kind.sigs.k8s.io/docs/user/ingress/#ingress-nginx
+  kubectl wait --namespace ingress-nginx \
+    --for=condition=ready pod \
+    --selector=app.kubernetes.io/component=controller \
+    --timeout=90s
+fi
 if [ "$INSTALL_KAFKA" == "true" ]; then
   kubectl wait kafka/$CLUSTER_NAME --for=condition=Ready --timeout=300s -n $NAMESPACE
 fi


### PR DESCRIPTION
Values file for testing:
```
core:
  initContainers:
    - name: nap-time
      image: alpine
      command: [ "sleep", "10" ]
    - name: make-a-file
      image: alpine
      command: [ "touch", "/opt/opennms-overlay/etc/this-is-a-file" ]
      volumeMounts:
      - name: overlay
        mountPath: /opt/opennms-overlay
```