### PR TITLE
 NMS-16317: Minion Container: Add way to overlay config files

### DIFF
--- a/horizon/Chart.yaml
+++ b/horizon/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.10
+version: 1.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "32.0.6"
+appVersion: "33.0.1"
 
 maintainers:
   - name: The OpenNMS Group Inc.

--- a/minion/Chart.yaml
+++ b/minion/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.10
+version: 1.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "32.0.6"
+appVersion: "33.0.1"
 
 maintainers:
   - name: The OpenNMS Group Inc.

--- a/minion/README.md
+++ b/minion/README.md
@@ -9,6 +9,16 @@ This template can be used to bring up a minion and connect it to a OpenNMS core.
 * Modify `values.yaml` file:
 * (If you are using JKS) add a base64 value of Java Keystore into `content`. You can get the base64 value by running `cat jks/truststore.jks | base64`
 
+## How to add/override files under `etc` folder:
+* Add your files to `etc` folder (*Note:* We don't support folders/subdirectories in this folder)
+* Deploy the Helm Chart
+  
+### Example:
+Adding a file called `hello.txt` to `etc` folder inside the minion container
+```
+$ echo "Hello World" > etc/hello.txt
+```
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/minion/README.md
+++ b/minion/README.md
@@ -9,16 +9,6 @@ This template can be used to bring up a minion and connect it to a OpenNMS core.
 * Modify `values.yaml` file:
 * (If you are using JKS) add a base64 value of Java Keystore into `content`. You can get the base64 value by running `cat jks/truststore.jks | base64`
 
-## How to add/override files under `etc` folder:
-* Add your files to `etc` folder (*Note:* We don't support folders/subdirectories in this folder)
-* Deploy the Helm Chart
-  
-### Example:
-Adding a file called `hello.txt` to `etc` folder inside the minion container
-```
-$ echo "Hello World" > etc/hello.txt
-```
-
 ## Values
 
 | Key | Type | Default | Description |

--- a/minion/README.md
+++ b/minion/README.md
@@ -16,7 +16,6 @@ This template can be used to bring up a minion and connect it to a OpenNMS core.
 ### Example:
 Adding a file called `hello.txt` to `etc` folder inside the minion container
 ```
-$ cd minion
 $ echo "Hello World" > etc/hello.txt
 ```
 

--- a/minion/README.md
+++ b/minion/README.md
@@ -9,6 +9,13 @@ This template can be used to bring up a minion and connect it to a OpenNMS core.
 * Modify `values.yaml` file:
 * (If you are using JKS) add a base64 value of Java Keystore into `content`. You can get the base64 value by running `cat jks/truststore.jks | base64`
 
+### Example:
+Adding a file called `hello.txt` to `etc` folder inside the minion container
+```
+cd minion
+echo "Hello World" > etc/hello.txt
+```
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/minion/README.md
+++ b/minion/README.md
@@ -16,6 +16,7 @@ This template can be used to bring up a minion and connect it to a OpenNMS core.
 ### Example:
 Adding a file called `hello.txt` to `etc` folder inside the minion container
 ```
+$ cd minion
 $ echo "Hello World" > etc/hello.txt
 ```
 

--- a/minion/README.md.gotmpl
+++ b/minion/README.md.gotmpl
@@ -9,6 +9,13 @@ This template can be used to bring up a minion and connect it to a OpenNMS core.
 * Modify `values.yaml` file:
 * (If you are using JKS) add a base64 value of Java Keystore into `content`. You can get the base64 value by running `cat jks/truststore.jks | base64`
 
+### Example:
+Adding a file called `hello.txt` to `etc` folder inside the minion container
+```
+$ cd minion
+$ echo "Hello World" > etc/hello.txt
+```
+
 {{ template "chart.valuesSection" . }}
 
 {{ template "helm-docs.versionFooter" . }}

--- a/minion/README.md.gotmpl
+++ b/minion/README.md.gotmpl
@@ -12,8 +12,8 @@ This template can be used to bring up a minion and connect it to a OpenNMS core.
 ### Example:
 Adding a file called `hello.txt` to `etc` folder inside the minion container
 ```
-$ cd minion
-$ echo "Hello World" > etc/hello.txt
+cd minion
+echo "Hello World" > etc/hello.txt
 ```
 
 {{ template "chart.valuesSection" . }}

--- a/minion/templates/minion-app-etc.configmap.yaml
+++ b/minion/templates/minion-app-etc.configmap.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: minion-app-etc
+data:
+  {{- (.Files.Glob "etc/**").AsConfig | nindent 2 }}
+

--- a/minion/templates/minion-deployment.yaml
+++ b/minion/templates/minion-deployment.yaml
@@ -104,6 +104,8 @@ spec:
             - mountPath: /opt/minion/minion-config.yaml
               name: minion-settings
               subPath: minion-config.yaml
+            - mountPath: "/opt/minion-etc-overlay"
+              name: minion-etc
             {{- if .Values.truststore.content }}
             - mountPath: /etc/java/jks
               name: jks
@@ -113,6 +115,9 @@ spec:
       hostname: minion
       restartPolicy: Always
       volumes:
+        - name: minion-etc
+          configMap:
+           name: minion-app-etc
         - name: minion-data-folder
           persistentVolumeClaim:
             claimName: minion-data-folder


### PR DESCRIPTION
Expanding the Minion helm chart by adding a configmap that places files under `/minion-etc-overlay` folder

Example:
`
$ cd minion
$ echo "Hello World" > etc/hello.txt
`

Limitations:
* Only supports flat layout, we don't support folders/subdirectories (This won't work `etc/test_folder/test.txt`)
* The configMap cannot be bigger than 1MB 
* We do not support any compression
* Support latests Container images