### PR TITLE
NMS-16364: helm chart values for minion resources is unintentionally being ignored

### DIFF
--- a/horizon/Chart.yaml
+++ b/horizon/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.11
+version: 1.1.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/minion/Chart.yaml
+++ b/minion/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.11
+version: 1.1.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/minion/templates/minion-deployment.yaml
+++ b/minion/templates/minion-deployment.yaml
@@ -61,9 +61,14 @@ spec:
               value: America/New_York
           image: {{ $image }}
           imagePullPolicy: {{ .Values.minion.image.pullPolicy }}
-          {{- if .Values.minion.resources }}
+          {{- with .Values.minion.resources }}
           resources:
-           {{- toYaml . | nindent 11 }}
+           limits:
+            cpu: {{ .limits.cpu }}
+            memory: {{ .limits.memory }}
+           requests:
+            cpu: {{ .requests.cpu }}
+            memory: {{ .requests.memory }}
           {{- end }}
           {{- if eq (include "onOpenShift" .) "true" }}
           securityContext:
@@ -99,7 +104,6 @@ spec:
               protocol: UDP
               name: syslog
            {{- end }}
-          resources: {}
           volumeMounts:
             - mountPath: /opt/minion/minion-config.yaml
               name: minion-settings


### PR DESCRIPTION
Removing duplicate `resources` property and fixing how we are passing resources value to the Minion Helm Chart