### PR TITLE
fix: Change liveness probe to readiness probe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 NOTES.md
 log.txt
 .DS_Store
+.idea/
 
 # Antora artifacts
 /build/

--- a/minion/templates/minion-deployment.yaml
+++ b/minion/templates/minion-deployment.yaml
@@ -85,7 +85,7 @@ spec:
              - ALL
            {{- end }}
           {{- end }}
-          livenessProbe:
+          readinessProbe:
             exec:
               command:
                 - /health.sh


### PR DESCRIPTION
If the health check fails, there is no real self-healing mechanism by restarting the Minion. It will just introduce a lot of unnecessary churn and makes adds instability in the system. It also makes it much more difficult to troubleshoot the real reason the health checks are failing.