### PR TITLE
Allow user to configure logging output in JSON format

### DIFF
--- a/horizon/Chart.yaml
+++ b/horizon/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.18
+version: 1.1.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/horizon/README.md
+++ b/horizon/README.md
@@ -114,6 +114,11 @@ kubectl create configmap -n $instance $configmap --from-file=lots-of-zeros.zip
 | core.configuration.http.restUsername | string | `"opennms"` |  |
 | core.configuration.instanceId | string | `"OpenNMS"` | Used only when multiTenant=false, otherwise it uses the release name |
 | core.configuration.nodeSelector | string | `nil` |  |
+| core.configuration.opennms_enviroment | string | `""` |  |
+| core.configuration.opennms_instance_id | string | `"OpenNMS"` |  |
+| core.configuration.opennms_log_console_daemon_output | string | `"ConsolePlain"` |  |
+| core.configuration.opennms_log_console_startup_output | string | `"ConsolePlain"` |  |
+| core.configuration.opennms_log_distribution | string | `"horizon"` |  |
 | core.configuration.ports.karaf.enabled | bool | `true` |  |
 | core.configuration.ports.karaf.externalPort | int | `8101` |  |
 | core.configuration.ports.syslog.enabled | bool | `true` |  |

--- a/horizon/README.md
+++ b/horizon/README.md
@@ -113,12 +113,11 @@ kubectl create configmap -n $instance $configmap --from-file=lots-of-zeros.zip
 | core.configuration.http.restPassword | string | `"admin"` |  |
 | core.configuration.http.restUsername | string | `"opennms"` |  |
 | core.configuration.instanceId | string | `"OpenNMS"` | Used only when multiTenant=false, otherwise it uses the release name |
+| core.configuration.logConsoleDaemonOutput | string | `"ConsolePlain"` |  |
+| core.configuration.logConsoleStartupOutput | string | `"ConsolePlain"` |  |
+| core.configuration.logDistribution | string | `"horizon"` |  |
+| core.configuration.logEnvironment | string | `""` |  |
 | core.configuration.nodeSelector | string | `nil` |  |
-| core.configuration.opennms_enviroment | string | `""` |  |
-| core.configuration.opennms_instance_id | string | `"OpenNMS"` |  |
-| core.configuration.opennms_log_console_daemon_output | string | `"ConsolePlain"` |  |
-| core.configuration.opennms_log_console_startup_output | string | `"ConsolePlain"` |  |
-| core.configuration.opennms_log_distribution | string | `"horizon"` |  |
 | core.configuration.ports.karaf.enabled | bool | `true` |  |
 | core.configuration.ports.karaf.externalPort | int | `8101` |  |
 | core.configuration.ports.syslog.enabled | bool | `true` |  |

--- a/horizon/templates/app-settings.configmap.yaml
+++ b/horizon/templates/app-settings.configmap.yaml
@@ -18,6 +18,10 @@ data:
   OPENNMS_DATABASE_CONNECTION_MINPOOL: {{ .Values.core.configuration.database.minPool | default "25" | quote }}
   OPENNMS_DATABASE_CONNECTION_MAXPOOL: {{ .Values.core.configuration.database.maxPool | default "50" | quote }}
   OPENNMS_WEB_BASEURL_SCHEME: {{ .Values.core.configuration.webBaseUrlScheme | quote }}
+  OPENNMS_LOG_CONSOLE_STARTUP_OUTPUT: {{ .Values.core.configuration.opennms_log_console_startup_output | quote }}
+  OPENNMS_LOG_CONSOLE_DAEMON_OUTPUT: {{ .Values.core.configuration.opennms_log_console_daemon_output | quote }}
+  OPENNMS_LOG_DISTRIBUTION: {{ .Values.core.configuration.opennms_log_distribution | quote }}
+  OPENNMS_ENVIRONMENT: {{ .Values.core.configuration.opennms_environment | quote }}
   ENABLE_ALEC: {{ ((.Values.core).configuration).enableAlec | default "false" | quote }}
   ENABLE_ACLS: {{ ((.Values.core).configuration).enableAcls | default "false" | quote }}
   CORE_SERVICE_ALARMD_ENABLED: {{ .Values.core.configuration.services.alarmd.enabled | quote }}

--- a/horizon/templates/app-settings.configmap.yaml
+++ b/horizon/templates/app-settings.configmap.yaml
@@ -18,10 +18,10 @@ data:
   OPENNMS_DATABASE_CONNECTION_MINPOOL: {{ .Values.core.configuration.database.minPool | default "25" | quote }}
   OPENNMS_DATABASE_CONNECTION_MAXPOOL: {{ .Values.core.configuration.database.maxPool | default "50" | quote }}
   OPENNMS_WEB_BASEURL_SCHEME: {{ .Values.core.configuration.webBaseUrlScheme | quote }}
-  OPENNMS_LOG_CONSOLE_STARTUP_OUTPUT: {{ .Values.core.configuration.opennms_log_console_startup_output | quote }}
-  OPENNMS_LOG_CONSOLE_DAEMON_OUTPUT: {{ .Values.core.configuration.opennms_log_console_daemon_output | quote }}
-  OPENNMS_LOG_DISTRIBUTION: {{ .Values.core.configuration.opennms_log_distribution | quote }}
-  OPENNMS_ENVIRONMENT: {{ .Values.core.configuration.opennms_environment | quote }}
+  OPENNMS_LOG_CONSOLE_STARTUP_OUTPUT: {{ .Values.core.configuration.logConsoleStartupOutput | quote }}
+  OPENNMS_LOG_CONSOLE_DAEMON_OUTPUT: {{ .Values.core.configuration.logConsoleDaemonOutput | quote }}
+  OPENNMS_LOG_DISTRIBUTION: {{ .Values.core.configuration.logDistribution | quote }}
+  OPENNMS_ENVIRONMENT: {{ .Values.core.configuration.logEnvironment | quote }}
   ENABLE_ALEC: {{ ((.Values.core).configuration).enableAlec | default "false" | quote }}
   ENABLE_ACLS: {{ ((.Values.core).configuration).enableAcls | default "false" | quote }}
   CORE_SERVICE_ALARMD_ENABLED: {{ .Values.core.configuration.services.alarmd.enabled | quote }}

--- a/horizon/values.schema.json
+++ b/horizon/values.schema.json
@@ -117,6 +117,28 @@
               "enum": ["http", "https"],
               "default": "https"
             },
+            "opennms_log_console_startup_output": {
+              "type": "string",
+              "enum": ["ConsolePlain", "ConsoleJson", "ConsoleNull"],
+              "default": "ConsolePlain"
+            },
+            "opennms_log_console_daemon_output": {
+              "type": "string",
+              "enum": ["ConsolePlain", "ConsoleJson", "ConsoleNull"],
+              "default": "ConsolePlain"
+            },
+            "opennms_log_distribution": {
+              "type": "string",
+              "default": "horizon"
+            },
+            "opennms_environment": {
+              "type": "string",
+              "default": ""
+            },
+            "opennms_instance_id": {
+              "type": "string",
+              "default": "OpenNMS"
+            },            
             "services": {
               "type": "object",
               "title": "Services",

--- a/horizon/values.schema.json
+++ b/horizon/values.schema.json
@@ -117,28 +117,28 @@
               "enum": ["http", "https"],
               "default": "https"
             },
-            "opennms_log_console_startup_output": {
+            "logConsoleStartupOutput": {
               "type": "string",
               "enum": ["ConsolePlain", "ConsoleJson", "ConsoleNull"],
-              "default": "ConsolePlain"
+              "default": "ConsolePlain",
+              "description": "Controls the format of manager logging output on startup. 'ConsolePlain' outputs human-readable text, 'ConsoleJson' outputs structured JSON for machine parsing, and 'ConsoleNull' suppresses console output."
             },
-            "opennms_log_console_daemon_output": {
+            "logConsoleDaemonOutput": {
               "type": "string",
               "enum": ["ConsolePlain", "ConsoleJson", "ConsoleNull"],
-              "default": "ConsolePlain"
+              "default": "ConsolePlain",
+              "description": "Controls the format of daemon logging output. 'ConsolePlain' outputs human-readable text, 'ConsoleJson' outputs structured JSON for machine parsing, and 'ConsoleNull' suppresses console output."
             },
-            "opennms_log_distribution": {
+            "logDistribution": {
               "type": "string",
-              "default": "horizon"
+              "default": "horizon",
+              "description": "Specifies the distribution identifier for logging purposes. This can help differentiate logs from different OpenNMS distributions."
             },
-            "opennms_environment": {
+            "logEnvironment": {
               "type": "string",
-              "default": ""
+              "default": "",
+              "description": "Specifies the environment identifier for logging purposes. Common values include 'production', 'staging', or 'development'."
             },
-            "opennms_instance_id": {
-              "type": "string",
-              "default": "OpenNMS"
-            },            
             "services": {
               "type": "object",
               "title": "Services",

--- a/horizon/values.yaml
+++ b/horizon/values.yaml
@@ -141,6 +141,11 @@ core:
     enableTssDualWrite: false
     enableAcls: false
     webBaseUrlScheme: https
+    opennms_log_console_startup_output: ConsolePlain
+    opennms_log_console_daemon_output: ConsolePlain
+    opennms_log_distribution: horizon
+    opennms_enviroment: ''
+    opennms_instance_id: OpenNMS
     services:
       alarmd:
         enabled: true

--- a/horizon/values.yaml
+++ b/horizon/values.yaml
@@ -141,11 +141,10 @@ core:
     enableTssDualWrite: false
     enableAcls: false
     webBaseUrlScheme: https
-    opennms_log_console_startup_output: ConsolePlain
-    opennms_log_console_daemon_output: ConsolePlain
-    opennms_log_distribution: horizon
-    opennms_enviroment: ''
-    opennms_instance_id: OpenNMS
+    logConsoleStartupOutput: ConsolePlain
+    logConsoleDaemonOutput: ConsolePlain
+    logDistribution: horizon
+    logEnvironment: ''
     services:
       alarmd:
         enabled: true


### PR DESCRIPTION
This PR adds support for configuring OpenNMS logging output format in JSON, allowing users to choose between plain text, JSON, or null console output for both startup and daemon logging.

## Key Changes

* Added five new configuration parameters for logging format control and instance identification
* Updated the Helm chart version from 1.1.17 to 1.1.18
* Added schema validation for the new logging output format options

Resolves: #66 