### PR TITLE
fix: Bump chart release version

### DIFF
--- a/horizon/Chart.yaml
+++ b/horizon/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.19
+version: 1.1.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
The GitHub releaser failed because 1.1.19 was already released from a previous PR.